### PR TITLE
도서관 열람실 잔여좌석 API 응답 형태 변경사항 대응

### DIFF
--- a/Sources/KuringMapsLink/KonkukLibraryLink.swift
+++ b/Sources/KuringMapsLink/KonkukLibraryLink.swift
@@ -42,10 +42,39 @@ public class KonkukLibraryLink {
         public let id: Int
         public let name: String
         public let roomType: RoomType
-        public let awaitable: Bool
+        public let awaitable: Bool?
+        public let waitRoomGroup: String?
         public let isChargeable: Bool
+        public let branch: Branch?
         public let unableMessage: String?
         public let seats: Seats
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case roomType
+            case waitRoomGroup
+            case awaitable
+            case isChargeable
+            case branch
+            case unableMessage
+            case seats
+        }
+        
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            self.id = try container.decode(Int.self, forKey: .id)
+            self.name = try container.decode(String.self, forKey: .name)
+            self.roomType = try container.decode(RoomType.self, forKey: .roomType)
+            self.awaitable = try? container.decodeIfPresent(Bool.self, forKey: .awaitable)
+            self.waitRoomGroup = try? container.decodeIfPresent(String.self, forKey: .waitRoomGroup)
+            
+            self.isChargeable = try container.decode(Bool.self, forKey: .isChargeable)
+            self.branch = try? container.decodeIfPresent(Branch.self, forKey: .branch)
+            self.unableMessage = try? container.decodeIfPresent(String.self, forKey: .unableMessage)
+            self.seats = try container.decode(Seats.self, forKey: .seats)
+        }
         
         public struct RoomType: Decodable, Identifiable, Equatable {
             public let id: Int
@@ -53,9 +82,36 @@ public class KonkukLibraryLink {
             public let sortOrder: Int
             
             // MARK: - @_spi(Tests)
-            @_spi(Tests) public init(id: Int, name: String, sortOrder: Int) {
+            @_spi(Tests) public init(
+                id: Int,
+                name: String,
+                sortOrder: Int
+            ) {
                 self.id = id
                 self.name = name
+                self.sortOrder = sortOrder
+            }
+        }
+        
+        public struct Branch: Decodable, Identifiable, Equatable {
+            public let id: Int
+            public let name: String
+            public let alias: String
+            public let libraryCode: String
+            public let sortOrder: Int
+            
+            // MARK: - @_spi(Tests)
+            @_spi(Tests) public init(
+                id: Int,
+                name: String,
+                alias: String,
+                libraryCode: String,
+                sortOrder: Int
+            ) {
+                self.id = id
+                self.name = name
+                self.alias = alias
+                self.libraryCode = libraryCode
                 self.sortOrder = sortOrder
             }
         }
@@ -67,7 +123,12 @@ public class KonkukLibraryLink {
             public let available: Int
             
             // MARK: - @_spi(Tests)
-            @_spi(Tests) public init(total: Int, occupied: Int, waiting: Int, available: Int) {
+            @_spi(Tests) public init(
+                total: Int,
+                occupied: Int,
+                waiting: Int,
+                available: Int
+            ) {
                 self.total = total
                 self.occupied = occupied
                 self.waiting = waiting
@@ -76,12 +137,24 @@ public class KonkukLibraryLink {
         }
         
         // MARK: - @_spi(Tests)
-        @_spi(Tests) public init(id: Int, name: String, roomType: RoomType, awaitable: Bool, isChargeable: Bool, unableMessage: String?, seats: Seats) {
+        @_spi(Tests) public init(
+            id: Int,
+            name: String,
+            roomType: RoomType,
+            awaitable: Bool,
+            waitRoomGroup: String? = nil,
+            isChargeable: Bool,
+            branch: Branch? = nil,
+            unableMessage: String?,
+            seats: Seats
+        ) {
             self.id = id
             self.name = name
             self.roomType = roomType
             self.awaitable = awaitable
+            self.waitRoomGroup = waitRoomGroup
             self.isChargeable = isChargeable
+            self.branch = branch
             self.unableMessage = unableMessage
             self.seats = seats
         }

--- a/Sources/KuringMapsUI/BottomSheet/KULibrary/Views/LibraryRoomList.swift
+++ b/Sources/KuringMapsUI/BottomSheet/KULibrary/Views/LibraryRoomList.swift
@@ -57,7 +57,7 @@ struct LibraryRoomList: View {
                     Button {
                         konkukLibrary.send(.refreshButtonTapped)
                     } label: {
-                        Image("icon.refresh")
+                        Image("icon.refresh", bundle: .module)
                             .rotationEffect(Angle(degrees: konkukLibrary.isAnimating ? 360 : 0))
                             .animation(
                                 .linear(duration: konkukLibrary.isAnimating ? 1 : 0)

--- a/Sources/KuringMapsUI/Map/KuringMap.swift
+++ b/Sources/KuringMapsUI/Map/KuringMap.swift
@@ -60,7 +60,7 @@ public struct KuringMap: View {
                     path.append(.libraryRoom)
                 } label: {
                     HStack(spacing: 6)  {
-                        Image("icon.library.book")
+                        Image("icon.library.book", bundle: .module)
                         
                         Text("열람실 좌석 현황")
                             .font(.system(size: 12))


### PR DESCRIPTION
# 사건의 전개 

- **어제부터(11/26) 도서관 열람실 잔여좌석 API가 계속 실패 했었음..**
<img width="337" height="727" alt="Screenshot 2025-11-27 at 6 39 38 PM" src="https://github.com/user-attachments/assets/1b2c7cce-09c4-406e-a7c8-fa6cdef0f55f" />

- 점검시간이라서 안되는가 싶었지만 
<img width="826" height="675" alt="Screenshot 2025-11-27 at 6 40 12 PM" src="https://github.com/user-attachments/assets/64adaf93-24c1-4704-a996-e75239e3415f" />

- 11시 이후에도 사용할수 없다함 ![scratch_head](https://github.com/user-attachments/assets/ba442aad-a8b2-482d-8649-86056f076bac)
<img width="697" height="723" alt="Screenshot 2025-11-27 at 6 41 49 PM" src="https://github.com/user-attachments/assets/31458fb5-6140-49f0-8a6a-ddd1463ff797" />

- 지금은(11/27) 이렇게 API 응답 형태가 바뀐 상태. 
<img width="482" height="725" alt="Screenshot 2025-11-27 at 6 44 01 PM" src="https://github.com/user-attachments/assets/31fa0f84-6293-4e75-93e9-d8534d25ba34" />

API 응답 형태가 바뀌어서 DTO 파싱에 실패하는것이 원인
```swift
keyNotFound(CodingKeys(stringValue: "awaitable", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "data", intValue: nil), CodingKeys(stringValue: "list", intValue: nil), _CodingKey(stringValue: "Index 0", intValue: 0)], debugDescription: "No value associated with key CodingKeys(stringValue: \"awaitable\", intValue: nil) (\"awaitable\").", underlyingError: nil))
```

## 변경사항

- `awaitable ` 필드 옵셔널로 변경
- `waitRoomGroup` 필드 추가
- `branch` 필드 추가 


# 스크린샷 
<!--- 작업된 내용의 스크린샷을 첨부 해주세요. -->
<!--- 번거롭더라도 부탁 드립니다~ 🙏 -->

![IMG_81BABE9DB4CF-1](https://github.com/user-attachments/assets/9d969be1-7621-42f2-b6b1-d9cbcb33400f)


# 논의사항

`waitRoomGroup`이랑 `branch`는 도서관 열람실 잔여좌석 화면에서 쓰지 않는 데이터임. 
`waitRoomGroup`이 String형식인지도 모르겠음. 뭐하는 필드인지 모르겠음. 
`seats`만 있으면 됨. 
